### PR TITLE
Fixing qt==5.12.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 22c3f340996502b66503affff2246b1f8b1c36a5e2906ea0307a831098e8d346
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<37]
 
 requirements:
@@ -37,7 +37,7 @@ requirements:
     - eigen  # [not win]
     - fftw  # [not win]
     - libtiff  # [not win]
-    - qt >=5.12.9  # [not win]
+    - qt ==5.12.5  # [not win]
   run:
     - python
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
